### PR TITLE
chore(publish): canary publish workflow

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,0 +1,45 @@
+name: Release - canary
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-canary:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    if: |
+      github.repository == 'carbon-design-system/carbon-for-ai'
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          fetch-depth: '0'
+      - run: |
+          git config user.name carbon-bot
+          git config user.email carbon@us.ibm.com
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.9.2
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build project
+        run: pnpm build
+      - name: Set NPM token
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+      - name: Publish canary release of packages
+        run: |
+          pnpm lerna publish --canary --preid canary --dist-tag canary


### PR DESCRIPTION
Closes #

Add github actions workflow that publishes the canary versions of the packages on push to `main`

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
