### PR TITLE
chore(cdn-workflow): add build step before dist step in cdn workflow

### DIFF
--- a/.github/workflows/publish-canary-cdn.yml
+++ b/.github/workflows/publish-canary-cdn.yml
@@ -29,6 +29,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Build packages
+        run: pnpm build
       - name: Build dist folders in each package
         run: pnpm build:dist:canary
       - name: Create one folder with dist contents from each package

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -27,6 +27,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Build packages
+        run: pnpm build
       - name: Build dist folders in each package
         run: pnpm build:dist
       - name: Create one folder with dist contents from each package


### PR DESCRIPTION
Closes #

Need to build packages before the `pnpm:dist` commands

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
