### PR TITLE
chore(stylelint): adjust stylelint rule to allow nesting

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,5 +1,6 @@
 {
-  "extends": [
-    "stylelint-config-carbon"
-  ]
+  "extends": ["stylelint-config-carbon"],
+  "rules": {
+    "max-nesting-depth": 2
+  }
 }


### PR DESCRIPTION
Closes #

The stylelint rule of max nesting set to 0 is a little too strict, opening up to have up to 2 levels of nesting

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
