### PR TITLE
feat(react): add react wrapper components

### DIFF
--- a/packages/chat/react/feedback.ts
+++ b/packages/chat/react/feedback.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createComponent } from '@lit/react';
+import Feedback from '../components/feedback/feedback.js';
+
+export const C4AIFeedback = createComponent({
+  tagName: 'c4ai-feedback',
+  elementClass: Feedback,
+  react: React,
+  events: {},
+});

--- a/packages/chat/react/test-input.ts
+++ b/packages/chat/react/test-input.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createComponent } from '@lit/react';
+import TestInput from '../components/test-input/test-input.js';
+
+export const C4AITestInput = createComponent({
+  tagName: 'c4ai-test-input',
+  elementClass: TestInput,
+  react: React,
+  events: {},
+});

--- a/packages/extended-button/react/extended-button.ts
+++ b/packages/extended-button/react/extended-button.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createComponent } from '@lit/react';
+import ExtendedButton from '../components/extended-button/extended-button.js';
+
+export const C4AIExtendedButton = createComponent({
+  tagName: 'c4ai-extended-button',
+  elementClass: ExtendedButton,
+  react: React,
+  events: {},
+});

--- a/packages/utilities/src/index.js
+++ b/packages/utilities/src/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './settings';
+export * from './settings/index.js';

--- a/packages/utilities/src/settings/index.js
+++ b/packages/utilities/src/settings/index.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { default as settings } from './settings';
+export { default as settings } from './settings.js';


### PR DESCRIPTION
Closes N/A

This PR adds React wrappers for existing components. This utilizes the `@lit/react` package - currently we need to manually create these React wrapper files, but looking into automating the file creation in the future.

#### Changelog

**New**

- React wrappers for existing components

**Changed**

- be specific with the reference paths for settings utilities package

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
