### PR TITLE
chore(build): separate build commands to each package

### DIFF
--- a/gulp-tasks/build/modules/css.js
+++ b/gulp-tasks/build/modules/css.js
@@ -37,40 +37,38 @@ const promisifyStream = promisify(asyncDone);
  * @private
  */
 const buildModulesCSS = ({ banner }) =>
-  gulp
-    .src([`packages/**/src/*.scss`])
-    .pipe(
-      sass({
-        includePaths: ['node_modules', '../../node_modules'],
-      })
-    )
-    .pipe(
-      postcss([
-        autoprefixer(),
-      ])
-    )
-    .pipe(cleanCSS())
-    .pipe(
-      through2.obj((file, enc, done) => {
-        file.contents = Buffer.from(`
-          import { css } from 'lit';
-          export default css([${JSON.stringify(String(file.contents))}]);
-        `);
-        file.path = replaceExtension(
-          file.path,
-        '.css.js'
-        );
-        done(null, file);
-      })
-    )
-    .pipe(prettier())
-    .pipe(header(banner))
-    .pipe(gulp.dest(function(file){
-      // output type files within the package folders itself (ie. packages/es/{component}/src/..)
-     const destPath = file.path.match(/(?<=packages\/)(.*?)(?=\/)/gm)[0];
-     file.dirname = file.dirname.replace(`/${destPath}`, '')
-     return `packages/${destPath}/es`;
-   }));
+ gulp
+  .src([`packages/${process.argv[4]}/**/src/*.scss`])
+  .pipe(
+    sass({
+      includePaths: ['node_modules', '../../node_modules'],
+    })
+  )
+  .pipe(
+    postcss([
+      autoprefixer(),
+    ])
+  )
+  .pipe(cleanCSS())
+  .pipe(
+    through2.obj((file, enc, done) => {
+      file.contents = Buffer.from(`
+        import { css } from 'lit';
+        export default css([${JSON.stringify(String(file.contents))}]);
+      `);
+      file.path = replaceExtension(
+        file.path,
+      '.css.js'
+      );
+      done(null, file);
+    })
+  )
+  .pipe(prettier())
+  .pipe(header(banner))
+  .pipe(gulp.dest(function(file){
+   const destPath = file.path.match(/(?<=packages\/)(.*?)(?=\/)/gm)[0];
+   return `packages/${destPath}/es/`;
+ }));
 
 /**
  * Builds the CSS

--- a/gulp-tasks/build/modules/scripts.js
+++ b/gulp-tasks/build/modules/scripts.js
@@ -27,11 +27,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 async function scripts() {
   const tsProject = ts.createProject(path.resolve(__dirname, '../../../tsconfig.json'));
   const {js} =  gulp.src([
-      `packages/**/*.ts`,
-      `!packages/**/*-story*.ts*`,
-      `!packages/**/__stories__/*.ts`,
-      `!packages/**/__tests__/*.ts`,
-      `!packages/**/*.d.ts`,
+      `packages/${process.argv[4]}/**/*.ts`,
+      `!packages/${process.argv[4]}/**/*-story*.ts*`,
+      `!packages/${process.argv[4]}/**/__stories__/*.ts`,
+      `!packages/${process.argv[4]}/**/__tests__/*.ts`,
+      `!packages/${process.argv[4]}/**/*.d.ts`,
     ]).pipe(sourcemaps.init()).pipe(tsProject());
 
   return js.pipe(
@@ -47,7 +47,6 @@ async function scripts() {
       .pipe(gulp.dest(function(file){
         // output type files within the package folders itself (ie. packages/es/{component}/src/..)
         const destPath = file.path.match(/(?<=packages\/)(.*?)(?=\/)/gm)[0];
-        file.dirname = file.dirname.replace(`/${destPath}`, '')
         return `packages/${destPath}/es`;
       }));
 }

--- a/gulp-tasks/build/modules/types.js
+++ b/gulp-tasks/build/modules/types.js
@@ -24,7 +24,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function types() {
   const tsProject = ts.createProject(path.resolve(__dirname, '../../../tsconfig.json'));
   const { dts } = gulp
-  .src([`packages/**/*.ts`, `!packages/**/__tests__/*.ts`, `!packages/**/*-story*.ts*`, `!packages/**/__stories__/*.ts`])
+  .src([`packages/${process.argv[4]}/**/*.ts`, `!packages/${process.argv[4]}/**/__tests__/*.ts`, `!packages/${process.argv[4]}/**/*-story*.ts*`, `!packages/${process.argv[4]}/**/__stories__/*.ts`])
   .pipe(sourcemaps.init())
   .pipe(tsProject());
 
@@ -39,7 +39,6 @@ return dts
   .pipe(gulp.dest(function(file){
      // output type files within the package folders itself (ie. packages/es/{component}/src/..)
     const destPath = file.path.match(/(?<=packages\/)(.*?)(?=\/)/gm)[0];
-    file.dirname = file.dirname.replace(`/${destPath}`, '')
     return `packages/${destPath}/es`;
   }));
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "./packages/*/es/": "./package/*/es/"
   },
   "scripts": {
-    "build": "rm -rf packages/*/es && lerna run build --scope @carbon/ai-utilities && gulp build",
+    "build": "lerna run build --stream",
     "build:dist": "lerna run build:dist --stream",
     "build:dist:canary": "lerna run build:dist:canary --stream",
     "build-storybook": "pnpm build && storybook build",
@@ -42,10 +42,8 @@
     "test:updateSnapshot": "pnpm build && web-test-runner \"packages/**/*.test.ts\" --node-resolve --update-snapshots"
   },
   "dependencies": {
-    "@babel/runtime": "^7.23.2",
     "@carbon/styles": "^1.45.0",
-    "@carbon/web-components": "2.1.2",
-    "lit": "^3.0.0"
+    "@carbon/web-components": "2.1.2"
   },
   "devDependencies": {
     "@carbon/grid": "^11.20.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "dependencies": {
     "@carbon/styles": "1.48.1",
-    "@carbon/web-components": "2.2.0"
+    "@carbon/web-components": "2.2.0",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@carbon/grid": "^11.21.1",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -29,6 +29,7 @@
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
+    "build": "gulp build --option chat",
     "build:dist": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js",
     "build:dist:canary": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js --configCanary"
   },

--- a/packages/extended-button/package.json
+++ b/packages/extended-button/package.json
@@ -29,6 +29,7 @@
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
+    "build": "gulp build --option extended-button",
     "build:dist": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js",
     "build:dist:canary": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js --configCanary"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,12 @@ importers:
 
   .:
     dependencies:
-      '@babel/runtime':
-        specifier: ^7.23.2
-        version: 7.23.2
       '@carbon/styles':
         specifier: ^1.45.0
         version: 1.45.0(sass@1.70.0)
       '@carbon/web-components':
         specifier: 2.1.2
         version: 2.1.2(sass@1.70.0)
-      lit:
-        specifier: ^3.0.0
-        version: 3.0.2
     devDependencies:
       '@carbon/grid':
         specifier: ^11.20.0
@@ -53,7 +47,7 @@ importers:
         version: 0.9.0
       '@lit/react':
         specifier: ^1.0.1
-        version: 1.0.1(@types/react@18.2.37)
+        version: 1.0.3(@types/react@18.2.37)
       '@open-wc/testing':
         specifier: ^4.0.0
         version: 4.0.0
@@ -3575,8 +3569,8 @@ packages:
   /@lit-labs/ssr-dom-shim@1.1.2:
     resolution: {integrity: sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==}
 
-  /@lit/react@1.0.1(@types/react@18.2.37):
-    resolution: {integrity: sha512-io4yIAl9ZFY5coI2ix+nSly4rmEKLFyZM66mxOr9xvxDqwtjdVU/g6Tchb7bo+A23+5Uu/1RZpLCpvHLCGi0rw==}
+  /@lit/react@1.0.3(@types/react@18.2.37):
+    resolution: {integrity: sha512-RGoPMrAPbFjQFXFbfmYdotw000DyChehTim+d562HRXvFGw//KxouI8jNOcc3Kw/1uqUA1SJqXFtKKxK0NUrww==}
     peerDependencies:
       '@types/react': 17 || 18
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@carbon/web-components':
         specifier: 2.2.0
         version: 2.2.0(sass@1.70.0)
+      lit:
+        specifier: ^3.0.0
+        version: 3.0.2
     devDependencies:
       '@carbon/grid':
         specifier: ^11.21.1


### PR DESCRIPTION
Closes #

This PR adds a build script to each package so that each package can run it's own build. Each package can build and run regardless of the other packages. Setting this up so that we can have publish workflows to publish only one specific package at a time.

#### Changelog

**Changed**

- build script for each package - each build script passes in the component name as an argument in the command and runs the gulp pipeline on just that specific package

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
