### PR TITLE
chore: onboard @carbon-labs/ai-chat to IBM Telemetry 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ check out our guides:
 
 Licensed under the
 [Apache 2.0 License](https://github.com/carbon-design-system/carbon-for-ai/blob/main/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+`@carbon-labs/ai-chat` uses IBM Telemetry to collect metrics data. By installing
+this package as a dependency you are agreeing to telemetry collection. To opt
+out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -24,18 +24,21 @@
     "**/*.d.ts",
     "**/*.js",
     "**/*.js.map",
-    "custom-elements.json"
+    "custom-elements.json",
+    "telemetry.yml"
   ],
   "types": "./src/index.d.ts",
   "customElements": "custom-elements.json",
   "scripts": {
     "build:dist": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js",
-    "build:dist:canary": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js --configCanary"
+    "build:dist:canary": "rm -rf dist && rollup --config ../../tools/rollup.config.dist.js --configCanary",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@carbon/ai-utilities": "0.0.1-rc.1",
     "@carbon/web-components": "2.2.0",
+    "@ibm/telemetry-js": "^1.2.0",
     "lit": "^3.0.0",
     "uuid": "^9.0.1"
   }

--- a/packages/chat/telemetry.yml
+++ b/packages/chat/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 7fbf7425-cf43-4071-a260-d681aade7109
+endpoint: "https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics"
+collect:
+  npm:
+    dependencies: null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@carbon/web-components':
         specifier: 2.2.0
         version: 2.2.0(sass@1.70.0)
+      '@ibm/telemetry-js':
+        specifier: ^1.2.0
+        version: 1.2.0
       lit:
         specifier: ^3.0.0
         version: 3.0.2
@@ -3371,6 +3374,12 @@ packages:
   /@ibm/plex@6.0.0-next.6:
     resolution: {integrity: sha512-B3uGruTn2rS5gweynLmfSe7yCawSRsJguJJQHVQiqf4rh2RNgJFu8YLE2Zd/JHV0ZXoVMOslcXP2k3hMkxKEyA==}
     engines: {node: '>=14'}
+    dev: false
+
+  /@ibm/telemetry-js@1.2.0:
+    resolution: {integrity: sha512-972XK1rRvZeVeSok4h2ILYV9bBq4YaJmRPRQP9oiinuI5ZdQwPbYJtXZa9KiZa9OD1At9b11pq3N1+J9VaJ0Mw==}
+    engines: {node: '>=16', npm: '>=8'}
+    hasBin: true
     dev: false
 
   /@isaacs/cliui@8.0.2:


### PR DESCRIPTION
Adds config required for telemetry collection to `@carbon-labs/ai-chat` package.

#### Changelog

**New**

- Added Telemetry disclosure to top-level README
- Added @ibm/telemetry-js dependency to `@carbon-labs/ai-chat`
- Added postinstall script to invoke telemetry collection
- Added telemetry.yml config file configured with npm scope.
- Included `telemetry.yml` in `@carbon-labs/ai-chat` package.json files

**Changed**

- N/A

**Removed**

- N/A

#### Testing / Reviewing

N/A
